### PR TITLE
US 3, Task 5 - Fix Terminate

### DIFF
--- a/src/main/java/memoranda/ui/AppFrame.java
+++ b/src/main/java/memoranda/ui/AppFrame.java
@@ -682,10 +682,7 @@ public class AppFrame extends JFrame {
 
     protected void processWindowEvent(WindowEvent e) {
         if (e.getID() == WindowEvent.WINDOW_CLOSING) {
-            if (Configuration.get("ON_CLOSE").equals("exit"))
                 doExit();
-            else
-                doMinimize();
         }
         else if ((e.getID() == WindowEvent.WINDOW_ICONIFIED)) {
             super.processWindowEvent(new WindowEvent(this,


### PR DESCRIPTION
Changed code so that it doesn't look at the configuration file anymore for the exit behavior. On the preference screen you were able to select if you wanted the window to close or just minimize on exit. We want it to close on exit, so I say we get rid of that part of the preferences and just let it close when we tell it to.  